### PR TITLE
Update images

### DIFF
--- a/bin/deploy-rabbit
+++ b/bin/deploy-rabbit
@@ -3,7 +3,7 @@
 SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 CONFIG=${CONFIG:-rabbitmq.config}
-IMAGE_TAG=${IMAGE_TAG:-3.10.0-rc.6-management}
+IMAGE_TAG=${IMAGE_TAG:-3.10-management}
 IMAGE=${IMAGE:-rabbitmq}
 OAUTH2_SERVER=${OAUTH2_SERVER:-uaa}
 

--- a/bin/deploy-uaa
+++ b/bin/deploy-uaa
@@ -5,6 +5,12 @@ SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT=$SCRIPT/..
 UAA_IMAGE_TAG=${UAA_IMAGE_TAG:-latest}
 
+arch=$(uname -m)
+if [ "$arch" == "amd64" ]; then
+	UAA_IMAGE_NAME="cloudfoundry/uaa"
+fi
+UAA_IMAGE_NAME=${UAA_IMAGE_NAME:-uaa}
+
 docker network inspect rabbitmq_net >/dev/null 2>&1 || docker network create rabbitmq_net
 docker rm -f uaa 2>/dev/null || echo "uaa was not running"
 
@@ -14,6 +20,6 @@ docker run \
 		--detach \
     --name uaa --net rabbitmq_net \
 		--publish 8080:8080 \
-		--mount type=bind,source=${ROOT}/conf/uaa,target=/etc/uaa \
+		--mount "type=bind,source=${ROOT}/conf/uaa,target=/etc/uaa" \
 		--env JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom" \
-    uaa:${UAA_IMAGE_TAG}
+    "${UAA_IMAGE_NAME}:${UAA_IMAGE_TAG}"


### PR DESCRIPTION
Uses latest `rabbitmq:3.10-management` image.
Uses pre-built `cloudfoundry/uaa` image when possible.