### PR TITLE
feat: plugins: enabling rabbitmq_web_mqtt

### DIFF
--- a/conf/enabled_plugins
+++ b/conf/enabled_plugins
@@ -1,1 +1,1 @@
-[rabbitmq_management,rabbitmq_auth_backend_oauth2].
+[rabbitmq_management,rabbitmq_auth_backend_oauth2,rabbitmq_web_mqtt].


### PR DESCRIPTION
MQTT example does not work because the MQTT plugin is not enabled.
This enables the `rabbitmq_web_mqtt` plugin (and implicitly the  `rabbitmq_mqtt`).